### PR TITLE
Fix: Removing duplicate method in exceptions

### DIFF
--- a/src/main/java/com/emazon/stock/infrastructure/configuration/exceptionhandler/HandlerControllerAdvisor.java
+++ b/src/main/java/com/emazon/stock/infrastructure/configuration/exceptionhandler/HandlerControllerAdvisor.java
@@ -33,9 +33,4 @@ public class HandlerControllerAdvisor {
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-    }
 }


### PR DESCRIPTION
The duplicate method that was passed when resolving conflicts was eliminated.